### PR TITLE
📝 Feature: CRUD Business Plan

### DIFF
--- a/frontend/src/stores/businessPlan.js
+++ b/frontend/src/stores/businessPlan.js
@@ -1,0 +1,167 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useAuthStore } from './auth.js'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8787'
+
+export const useBusinessPlanStore = defineStore('businessPlan', () => {
+  const authStore = useAuthStore()
+  
+  // State
+  const businessPlans = ref([])
+  const currentPlan = ref(null)
+  const loading = ref(false)
+  const error = ref(null)
+  
+  // Getters
+  const hasPlans = computed(() => businessPlans.value.length > 0)
+  
+  // Actions
+  async function fetchBusinessPlans() {
+    loading.value = true
+    error.value = null
+    
+    try {
+      const res = await fetch(`${API_URL}/api/business-plans`, {
+        headers: { 'Authorization': `Bearer ${authStore.token}` }
+      })
+      
+      const data = await res.json()
+      
+      if (!res.ok) {
+        throw new Error(data.error || 'Erreur')
+      }
+      
+      businessPlans.value = data.businessPlans
+      return data.businessPlans
+    } catch (e) {
+      error.value = e.message
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+  
+  async function createBusinessPlan(name) {
+    loading.value = true
+    error.value = null
+    
+    try {
+      const res = await fetch(`${API_URL}/api/business-plans`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authStore.token}`
+        },
+        body: JSON.stringify({ name })
+      })
+      
+      const data = await res.json()
+      
+      if (!res.ok) {
+        throw new Error(data.error || 'Erreur')
+      }
+      
+      businessPlans.value.unshift(data)
+      return data
+    } catch (e) {
+      error.value = e.message
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+  
+  async function fetchBusinessPlan(id) {
+    loading.value = true
+    error.value = null
+    
+    try {
+      const res = await fetch(`${API_URL}/api/business-plans/${id}`, {
+        headers: { 'Authorization': `Bearer ${authStore.token}` }
+      })
+      
+      const data = await res.json()
+      
+      if (!res.ok) {
+        throw new Error(data.error || 'Erreur')
+      }
+      
+      currentPlan.value = data
+      return data
+    } catch (e) {
+      error.value = e.message
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+  
+  async function updateSection(id, section, data) {
+    error.value = null
+    
+    try {
+      const res = await fetch(`${API_URL}/api/business-plans/${id}/${section}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${authStore.token}`
+        },
+        body: JSON.stringify(data)
+      })
+      
+      const result = await res.json()
+      
+      if (!res.ok) {
+        throw new Error(result.error || 'Erreur')
+      }
+      
+      // Update current plan if loaded
+      if (currentPlan.value && currentPlan.value.id === id) {
+        currentPlan.value.data = { ...currentPlan.value.data, [section]: data }
+        currentPlan.value.progress = result.progress
+      }
+      
+      return result
+    } catch (e) {
+      error.value = e.message
+      throw e
+    }
+  }
+  
+  async function deleteBusinessPlan(id) {
+    try {
+      const res = await fetch(`${API_URL}/api/business-plans/${id}`, {
+        method: 'DELETE',
+        headers: { 'Authorization': `Bearer ${authStore.token}` }
+      })
+      
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Erreur')
+      }
+      
+      businessPlans.value = businessPlans.value.filter(p => p.id !== id)
+      
+      if (currentPlan.value?.id === id) {
+        currentPlan.value = null
+      }
+    } catch (e) {
+      error.value = e.message
+      throw e
+    }
+  }
+  
+  return {
+    businessPlans,
+    currentPlan,
+    loading,
+    error,
+    hasPlans,
+    fetchBusinessPlans,
+    createBusinessPlan,
+    fetchBusinessPlan,
+    updateSection,
+    deleteBusinessPlan
+  }
+})

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -4,45 +4,80 @@
     <header class="bg-white border-b">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-between items-center">
         <h1 class="text-xl font-bold">Mes Business Plans</h1>
-        <router-link 
-          to="/funnel"
-          class="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700"
-        >
-          + Nouveau
-        </router-link>
+        <div class="flex items-center gap-4">
+          <span v-if="authStore.user" class="text-sm text-gray-600">
+            {{ authStore.user.email }}
+          </span>
+          <button 
+            @click="showCreateModal = true"
+            class="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700"
+          >
+            + Nouveau
+          </button>
+          <button 
+            @click="authStore.logout(); $router.push('/')"
+            class="text-gray-600 hover:text-gray-900"
+          >
+            Déconnexion
+          </button>
+        </div>
       </div>
     </header>
 
     <!-- Content -->
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div v-if="businessPlans.length === 0" class="text-center py-12">
-        <p class="text-gray-500">Vous n'avez pas encore de business plan.</p>
-        <router-link 
-          to="/funnel"
-          class="mt-4 inline-block text-primary-600 hover:text-primary-700"
-        >
-          Créer mon premier →
-        </router-link>
+      <!-- Loading -->
+      <div v-if="bpStore.loading" class="text-center py-12">
+        <div class="w-12 h-12 border-4 border-primary-600 border-t-transparent rounded-full animate-spin mx-auto"></div>
       </div>
 
+      <!-- Empty state -->
+      <div v-else-if="!bpStore.hasPlans" class="text-center py-12">
+        <div class="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+          </svg>
+        </div>
+        <p class="text-gray-500">Vous n'avez pas encore de business plan.</p>
+        <button 
+          @click="showCreateModal = true"
+          class="mt-4 text-primary-600 hover:text-primary-700"
+        >
+          Créer mon premier →
+        </button>
+      </div>
+
+      <!-- List -->
       <div v-else class="grid gap-4">
         <div 
-          v-for="plan in businessPlans" 
+          v-for="plan in bpStore.businessPlans" 
           :key="plan.id"
           class="bg-white p-6 rounded-xl shadow-sm flex items-center justify-between"
         >
           <div>
             <h3 class="font-semibold text-lg">{{ plan.name }}</h3>
-            <p class="text-sm text-gray-500">
-              Progression: {{ plan.progress }}% • {{ plan.status }}
-            </p>
+            <div class="flex items-center gap-4 mt-1">
+              <span class="text-sm text-gray-500">
+                Progression: {{ plan.progress }}%
+              </span>
+              <span class="text-sm text-gray-400">
+                {{ new Date(plan.updated_at).toLocaleDateString('fr-FR') }}
+              </span>
+            </div>
+            <!-- Progress bar -->
+            <div class="w-48 h-2 bg-gray-200 rounded-full mt-2">
+              <div 
+                class="h-full bg-primary-600 rounded-full transition-all"
+                :style="{ width: `${plan.progress}%` }"
+              />
+            </div>
           </div>
           <div class="flex gap-2">
             <router-link 
               :to="`/funnel/${plan.id}`"
               class="text-primary-600 hover:text-primary-700 px-3 py-1"
             >
-              Modifier
+              {{ plan.progress > 0 ? 'Continuer' : 'Commencer' }}
             </router-link>
             <button 
               @click="exportPDF(plan.id)"
@@ -50,27 +85,79 @@
             >
               PDF
             </button>
+            <button 
+              @click="bpStore.deleteBusinessPlan(plan.id)"
+              class="text-red-600 hover:text-red-700 px-3 py-1"
+            >
+              Suppr
+            </button>
           </div>
         </div>
       </div>
     </main>
+
+    <!-- Create Modal -->
+    <div v-if="showCreateModal" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div class="bg-white rounded-xl p-6 w-full max-w-md">
+        <h2 class="text-xl font-semibold mb-4">Nouveau Business Plan</h2>
+        <input 
+          v-model="newPlanName"
+          type="text"
+          placeholder="Nom du projet"
+          class="w-full rounded-lg border border-gray-300 px-3 py-2 mb-4"
+          @keyup.enter="createPlan"
+        />
+        <div class="flex justify-end gap-2">
+          <button 
+            @click="showCreateModal = false"
+            class="px-4 py-2 text-gray-600 hover:text-gray-900"
+          >
+            Annuler
+          </button>
+          <button 
+            @click="createPlan"
+            :disabled="!newPlanName || bpStore.loading"
+            class="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 disabled:opacity-50"
+          >
+            {{ bpStore.loading ? 'Création...' : 'Créer' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth.js'
+import { useBusinessPlanStore } from '../stores/businessPlan.js'
 
-const businessPlans = ref([])
+const router = useRouter()
+const authStore = useAuthStore()
+const bpStore = useBusinessPlanStore()
 
-onMounted(async () => {
-  // TODO: Fetch from API
-  businessPlans.value = [
-    { id: 'bp-1', name: 'Mon Startup', progress: 45, status: 'draft' }
-  ]
+const showCreateModal = ref(false)
+const newPlanName = ref('')
+
+onMounted(() => {
+  bpStore.fetchBusinessPlans()
 })
 
+async function createPlan() {
+  if (!newPlanName.value) return
+  
+  try {
+    const plan = await bpStore.createBusinessPlan(newPlanName.value)
+    showCreateModal.value = false
+    newPlanName.value = ''
+    router.push(`/funnel/${plan.id}`)
+  } catch (e) {
+    // Error handled in store
+  }
+}
+
 function exportPDF(id) {
-  // TODO: Call export API
-  alert('Export PDF: ' + id)
+  alert('Export PDF à implémenter - Issue #27')
 }
 </script>


### PR DESCRIPTION
Closes #25

## ✅ Implémenté

### Backend
- GET /api/business-plans - Liste des BP de l'user connecté
- POST /api/business-plans - Création nouveau BP
- GET /api/business-plans/:id - Détail avec data JSON
- PUT /api/business-plans/:id/:section - Update section + calcul progress auto
- DELETE /api/business-plans/:id - Suppression
- Toutes les routes protégées par middleware auth

### Frontend
- Store Pinia businessPlan avec fetch, create, updateSection, delete
- Dashboard avec liste des BP
- Progress bars visuelles
- Modal création rapide
- Actions: continuer / PDF / supprimer

### Calcul Progress
- Sections: businessInfo, market, financial
- Progress = (sections complétées / 3) × 100

## 🧪 Pour tester

1. Se connecter
2. Dashboard → Créer un BP
3. Remplir des sections → progress s'update

## 📋 Dépendances

⚠️ Nécessite la PR #39 (Auth Magic Link) pour fonctionner

---
*En attente de review @LeadDev*